### PR TITLE
Fix TypeError

### DIFF
--- a/vim/merlin/rplugin/python3/deoplete/sources/deoplete_ocaml.py
+++ b/vim/merlin/rplugin/python3/deoplete/sources/deoplete_ocaml.py
@@ -98,7 +98,7 @@ class Source(Base):
             self.vim.buffers[buf].append(errors.split(b'\n'))
 
         try:
-            result_json = json.loads(output)
+            result_json = json.loads(output.decode('utf-8'))
             value = result_json["value"]
             entries = value["entries"]
         except Exception as e:


### PR DESCRIPTION
Fixes TypeError("the JSON object must be str, not 'bytes'",) thrown in json.loads.